### PR TITLE
14-day trial and owner bypass stripe

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -261,7 +261,7 @@ const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       const { data, error } =
         await supabase.functions.invoke('check-subscription');
       if (error) throw error;
-      console.log('[AuthContext] Subscription status:', data);
+      console.log('[AuthContext] Subscription status:', { data });
       setSubscribed(data.subscribed || false);
       setSubscriptionSuspended(data.suspended || false);
       setSubscriptionTier(data.subscription_tier || null);

--- a/src/pages/auth/Register.tsx
+++ b/src/pages/auth/Register.tsx
@@ -133,13 +133,26 @@ const Register: React.FC = () => {
     try {
       // Pre-check if email already exists
       console.log('Checking if email exists...');
-      const emailCheckResult = await checkEmailExists(email.trim());
-      
+      const emailCheckResult = await checkEmailExists(email.trim(), organizationName.trim());
+
+      if (emailCheckResult?.organization_exists) {
+        const errorMessage = 'This organization name is already taken. Please contact the organization administrator to request access, or choose a different organization name.';
+        setError(errorMessage);
+        toast({
+          title: "Organization Already Exists",
+          description: errorMessage,
+          variant: "destructive",
+          duration: 8000,
+        });
+        setLoading(false);
+        return;
+      }
+
       if (emailCheckResult?.exists) {
-        const errorMessage = emailCheckResult.is_active 
+        const errorMessage = emailCheckResult.is_active
           ? 'This email is already registered and cannot be used to register again. Please login or use "Forgot Password" if needed.'
           : 'This email is registered but not yet activated. Please check your inbox or use "Forgot Password" to complete activation.';
-        
+
         setError(errorMessage);
         toast({
           title: emailCheckResult.is_active ? "Email Already Registered" : "Email Pending Activation",
@@ -308,7 +321,7 @@ const Register: React.FC = () => {
     
     setEmailCheckingLoading(true);
     try {
-      const result = await checkEmailExists(email.trim());
+      const result = await checkEmailExists(email.trim(), organizationName.trim() || undefined);
       if (result?.exists) {
         const message = result.is_active 
           ? 'This email is already registered. Please use login instead.'

--- a/src/utils/supabase-helpers.ts
+++ b/src/utils/supabase-helpers.ts
@@ -285,12 +285,12 @@ export const updateUser = async (params: {
 /**
  * Check if an email already exists and its status
  */
-export const checkEmailExists = async (email: string) => {
+export const checkEmailExists = async (email: string, organizationName?: string) => {
   try {
     const { data, error } = await supabase.functions.invoke('admin-utils', {
       body: {
         action: 'check_email_exists',
-        params: { email },
+        params: { email, organization_name: organizationName },
       },
     });
 

--- a/supabase/functions/_shared/user-management.ts
+++ b/supabase/functions/_shared/user-management.ts
@@ -130,8 +130,24 @@ export async function enableUserWithoutConfirmation(userId) {
     throw error;
   }
 }
-export async function checkEmailExists(email) {
+export async function checkEmailExists(email, organizationName?) {
   const supabaseAdmin = await getSupabaseAdmin();
+
+  // Check organization name uniqueness if provided
+  let organizationExists = false;
+  if (organizationName) {
+    const { data: orgData, error: orgError } = await supabaseAdmin
+      .from('organizations')
+      .select('id')
+      .ilike('name', organizationName.trim())
+      .maybeSingle();
+    if (orgError) {
+      console.error('Error checking organization:', orgError);
+    } else {
+      organizationExists = !!orgData;
+    }
+  }
+
   const perPage = 100;
   let page = 1;
   let user = null;
@@ -148,15 +164,16 @@ export async function checkEmailExists(email) {
       (u) => u.email.toLowerCase() === email.toLowerCase()
     );
     if (user) break;
-    // If less than a full page returned, we've hit the end
     if (data.users.length < perPage) break;
     page++;
   }
+
   if (!user)
     return {
       exists: false,
+      organization_exists: organizationExists,
     };
-  // Check profile for is_active
+
   const { data: profile, error: profileError } = await supabaseAdmin
     .from('profiles')
     .select('is_active')
@@ -166,12 +183,14 @@ export async function checkEmailExists(email) {
     console.error('Error fetching profile:', profileError);
     return {
       exists: true,
-      is_active: true, // default to true if uncertain
+      is_active: true,
+      organization_exists: organizationExists,
     };
   }
   return {
     exists: true,
     is_active: profile.is_active,
+    organization_exists: organizationExists,
   };
 }
 export async function updateUser(input) {

--- a/supabase/functions/admin-utils/index.ts
+++ b/supabase/functions/admin-utils/index.ts
@@ -593,7 +593,7 @@ serve(async (req) => {
           );
         }
         try {
-          const result = await checkEmailExists(params.email);
+          const result = await checkEmailExists(params.email, params.organization_name);
           return new Response(JSON.stringify(result), {
             headers: { ...corsHeaders, 'Content-Type': 'application/json' },
           });

--- a/supabase/functions/check-subscription/index.ts
+++ b/supabase/functions/check-subscription/index.ts
@@ -15,6 +15,47 @@ const logStep = (step: string, details?: any) => {
   console.log(`[CHECK-SUBSCRIPTION] ${step}${detailsStr}`);
 };
 
+const TRIAL_DAYS = 14;
+
+async function checkTrialStatus(supabaseClient: any, userId: string) {
+  const { data: profile } = await supabaseClient
+    .from('profiles')
+    .select('organization_id')
+    .eq('id', userId)
+    .single();
+
+  if (!profile?.organization_id) {
+    return { subscribed: false };
+  }
+
+  const { data: org } = await supabaseClient
+    .from('organizations')
+    .select('created_at')
+    .eq('id', profile.organization_id)
+    .single();
+
+  if (!org?.created_at) {
+    return { subscribed: false };
+  }
+
+  const createdAt = new Date(org.created_at);
+  const trialEnd = new Date(
+    createdAt.getTime() + TRIAL_DAYS * 24 * 60 * 60 * 1000
+  );
+  const now = new Date();
+
+  if (now <= trialEnd) {
+    return {
+      subscribed: true,
+      subscription_tier: 'Trial',
+      subscription_end: trialEnd.toISOString(),
+      suspended: false,
+    };
+  }
+
+  return { subscribed: false };
+}
+
 serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
@@ -50,6 +91,26 @@ serve(async (req) => {
       throw new Error('User not authenticated or email not available');
     logStep('User authenticated', { userId: user.id, email: user.email });
 
+    const OWNER_EMAILS = [
+      'gearheadgarage.pk@gmail.com',
+      'daniyal.reviewer@gmail.com',
+    ];
+    if (OWNER_EMAILS.includes(user.email)) {
+      logStep('Owner account detected, granting Enterprise access');
+      return new Response(
+        JSON.stringify({
+          subscribed: true,
+          subscription_tier: 'Enterprise',
+          subscription_end: null,
+          suspended: false,
+        }),
+        {
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+          status: 200,
+        }
+      );
+    }
+
     const stripe = new Stripe(stripeKey, { apiVersion: '2023-10-16' });
     const customers = await stripe.customers.list({
       email: user.email,
@@ -57,20 +118,10 @@ serve(async (req) => {
     });
 
     if (customers.data.length === 0) {
-      logStep('No customer found, updating unsubscribed state');
-      // await supabaseClient.from('subscribers').upsert(
-      //   {
-      //     email: user.email,
-      //     user_id: user.id,
-      //     stripe_customer_id: null,
-      //     subscribed: false,
-      //     subscription_tier: null,
-      //     subscription_end: null,
-      //     updated_at: new Date().toISOString(),
-      //   },
-      //   { onConflict: 'email' }
-      // );
-      return new Response(JSON.stringify({ subscribed: false }), {
+      logStep('No Stripe customer found, checking trial eligibility');
+      const trialResult = await checkTrialStatus(supabaseClient, user.id);
+      logStep('Trial check result', trialResult);
+      return new Response(JSON.stringify(trialResult), {
         headers: { ...corsHeaders, 'Content-Type': 'application/json' },
         status: 200,
       });
@@ -126,7 +177,21 @@ serve(async (req) => {
         subscriptionTier,
       });
     } else {
-      logStep('No active subscription found');
+      logStep('No active subscription found, checking trial eligibility');
+      const trialResult = await checkTrialStatus(supabaseClient, user.id);
+      if (trialResult.subscribed) {
+        logStep('User is within trial period', trialResult);
+        return new Response(
+          JSON.stringify({
+            ...trialResult,
+            suspended: subscriber?.suspended || false,
+          }),
+          {
+            headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+            status: 200,
+          }
+        );
+      }
     }
 
     // await supabaseClient.from("subscribers").upsert({


### PR DESCRIPTION
Add 14-day trial period and owner bypass for subscription checks
- New orgs automatically get a 14-day free trial based on organization created_at, no Stripe setup required
- Hardcoded owner emails bypass Stripe entirely and receive permanent Enterprise access
- checkEmailExists now validates organization name uniqueness at registration time, preventing duplicate org names before signup